### PR TITLE
 moved to protobuf version 3.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.ghaskins/protobuf "3.0.2-2"
+(defproject org.clojars.ghaskins/protobuf "3.1.0"
   :description "Clojure-protobuf provides a clojure interface to Google's protocol buffers."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -7,7 +7,7 @@
   :java-source-paths ["src"]
   :lein-release {:deploy-via :clojars}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.google.protobuf/protobuf-java "3.0.2"]
+                 [com.google.protobuf/protobuf-java "3.1.0"]
                  [org.flatland/useful "0.11.5"]
                  [org.flatland/schematic "0.1.5"]
                  [org.flatland/io "0.3.0"]


### PR DESCRIPTION
Updated for protobuf version 3.1.0. 
This isn't the latest version, but is used by Tensorflow. 